### PR TITLE
Enhance URL handling and ensure proper link card creation for various cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i remark-link-card-plus
 
 ### Basic Example
 
-```javascript
+```js
 import { remark } from "remark";
 import remarkLinkCard from "remark-link-card-plus";
 
@@ -58,6 +58,38 @@ Inline links like [GitHub](https://github.com) will **not** be converted.
 
   console.log(result.value);
 })();
+```
+
+You can get converted result like this.
+
+```md
+# Example Markdown
+
+## Link Card Demo
+
+Bare links like this:
+
+<div class="remark-link-card-plus__container">
+  <a href="https://github.com/" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">GitHub · Build and ship software on a single, collaborative platform</div>
+        <div class="remark-link-card-plus__description">Join the world's most widely adopted, AI-powered developer platform where millions of developers, businesses, and the largest open source community build software that advances humanity.</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=github.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">github.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="https://github.githubassets.com/assets/home24-5939032587c9.jpg" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+will be converted into a link card.
+
+Inline links like [GitHub](https://github.com) will **not** be converted.
 ```
 
 ### Astro Example

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,10 +50,110 @@ describe("remark-link-card-plus", () => {
     test("Convert a line with only a link into a card", async () => {
       const input = `## test
 
+https://example.com
+
+https://example.com/path
+
+<https://example.com>
+
+<https://example.com/path>
+
+[https://example.com](https://example.com)
+
 [https://example.com/path](https://example.com/path)
 `;
       const { value } = await processor.process(input);
       const expected = `## test
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/path" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/path" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
 
 <div class="remark-link-card-plus__container">
   <a href="https://example.com/path" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
@@ -104,6 +204,68 @@ describe("remark-link-card-plus", () => {
       expect(value.toString()).toBe(expected);
     });
 
+    test("Does not convert links inside list items to link cards", async () => {
+      const input = `## test
+
+* list
+  * https://example.com
+  * [https://example.com](https://example.com)
+  * <https://example.com>
+  * https://example.com/path
+  * [https://example.com/path](https://example.com/path)
+  * <https://example.com/path>
+
+
+* https://example.com
+* [https://example.com](https://example.com)
+* <https://example.com>
+* https://example.com/path
+* [https://example.com/path](https://example.com/path)
+* <https://example.com/path>
+`;
+      const { value } = await processor().process(input);
+      const expected = `## test
+
+* list
+  * https://example.com
+  * <https://example.com>
+  * <https://example.com>
+  * https://example.com/path
+  * <https://example.com/path>
+  * <https://example.com/path>
+
+* https://example.com
+
+* <https://example.com>
+
+* <https://example.com>
+
+* https://example.com/path
+
+* <https://example.com/path>
+
+* <https://example.com/path>
+`;
+      expect(value.toString()).toBe(expected);
+    });
+
+    test("Does not convert if link text is a URL but different from the link URL", async () => {
+      const input = `## test
+
+[https://example.com](https://example.org)
+`;
+
+      const { value } = await processor.process(input);
+      const expected = `## test
+
+[https://example.com](https://example.org)
+`;
+
+      expect(removeLineLeadingSpaces(value.toString())).toBe(
+        removeLineLeadingSpaces(expected),
+      );
+    });
+
     test("Does not show a favicon if the favicon request fails", async () => {
       server.use(
         http.head("https://www.google.com/s2/favicons", () => {
@@ -147,7 +309,7 @@ describe("remark-link-card-plus", () => {
         result: {
           ogTitle: "Test Site Title",
           ogDescription: "Test Description",
-          ogImage: { url: "example.com" },
+          ogImage: [{ url: "example.com" }],
         },
       });
 


### PR DESCRIPTION
This pull request includes several changes to improve the `remark-link-card-plus` package. The most important changes include updates to the `README.md` file, enhancements to the test cases in `src/index.test.ts`, and modifications to the main plugin logic in `src/index.ts`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36): Updated code block language identifier from `javascript` to `js` and added a detailed example showing how links are converted to link cards. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R94)

Test enhancements:

* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R207-R268): Added new test cases to ensure links inside list items are not converted to link cards, and to verify that links with different link text and URL are not converted.
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R53-R157): Modified existing tests to include additional link formats and ensure correct conversion to link cards.
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L150-R312): Updated test data to handle multiple `ogImage` entries correctly.

Plugin logic improvements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L38-L65): Enhanced the plugin to handle unmatched links and avoid converting links with different link text and URL. Also, refactored the logic to add transformers for processing links.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L135-L142): Improved the `getLinkCardData` function to validate `ogImage` URLs more robustly.

Type adjustments:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R4): Added `Link` type import from `mdast` to improve type safety.