### PR TITLE
Add `noThumbnail` and `noFavicon` options to exclude images and favicons from link cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can see it in action on the [demo page](https://remark-link-card-plus.pages.
 * **Target blank**: Links in link cards now open in a new tab using `target="_blank"`.
 * **No link cards in lists**: Links inside list items (`listItem`) are not converted into link cards.
 * **Thumbnail position customization**: Select whether the thumbnail is displayed on the left or right of the card.
+* **Optional image and favicon display**: Added `noThumbnail` and `noFavicon` options to hide thumbnails and favicons from link cards.
 
 ### Retained features:
 * **Options support**:
@@ -99,13 +100,9 @@ You can also use `remark-link-card-plus` in an [Astro](https://astro.build) proj
 ```javascript
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
 import remarkLinkCard from 'remark-link-card-plus';
 
 export default defineConfig({
-  integrations: [
-    tailwind(),
-  ],
   markdown: {
     remarkPlugins: [
       [
@@ -113,9 +110,18 @@ export default defineConfig({
           cache: true,
           shortenUrl: true,
           thumbnailPosition: "right",
+          noThumbnail: false,
+          noFavicon: false,
         },
       ],
     ],
+  },
+});
+
+// Here is minimal setup.
+export default defineConfig({
+  markdown: {
+    remarkPlugins: [remarkLinkCard],
   },
 });
 ```
@@ -124,9 +130,11 @@ export default defineConfig({
 
 | Option       | Type    | Default | Description                                                                 |
 |--------------|---------|---------|-----------------------------------------------------------------------------|
-| `cache`      | boolean | `false` | Caches Open Graph images and favicons locally. Images are saved to `process.cwd()/public/remark-link-card-plus/` and paths start with `/remark-link-card-plus/`. This reduces server load on the linked site. |
+| `cache`      | boolean | `false` | Caches Open Graph images and favicons locally. Images are saved to `process.cwd()/public/remark-link-card-plus/` and paths start with `/remark-link-card-plus/`. This reduces server load on the linked site and improves build performance by avoiding redundant network requests. |
 | `shortenUrl` | boolean | `true`  | Displays only the hostname of the URL in the link card instead of the full URL. |
 | `thumbnailPosition` | string | `right`  | Specifies the position of the thumbnail in the card. Accepts `"left"` or `"right"`. |
+| `noThumbnail` | boolean | `false` | If `true`, does not display the Open Graph thumbnail image. The generated link card HTML will not contain an `<img>` tag for the thumbnail. |
+| `noFavicon`   | boolean | `false` | If `true`, does not display the favicon in the link card. The generated link card HTML will not contain an `<img>` tag for the favicon. |
 
 ## Styling
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ const getFaviconUrl = async (url: URL, options: Options) => {
   if (options.noFavicon) return "";
 
   let faviconUrl = await getFaviconImageSrc(url);
-  if (options.cache) {
+  if (faviconUrl && options.cache) {
     try {
       const faviconFilename = await downloadImage(
         new URL(faviconUrl),
@@ -205,23 +205,22 @@ const getOgImageUrl = async (
 ) => {
   if (options.noThumbnail) return "";
 
-  let ogImageUrl =
+  const isValidUrl =
     ogResult?.ogImage &&
     ogResult.ogImage.length > 0 &&
-    URL.canParse(ogResult?.ogImage[0].url)
-      ? ogResult?.ogImage?.[0].url
-      : "";
+    URL.canParse(ogResult.ogImage[0].url);
+  if (!isValidUrl) return "";
 
-  if (ogImageUrl) {
-    if (options.cache) {
-      const imageFilename = await downloadImage(
-        new URL(ogImageUrl),
-        path.join(process.cwd(), defaultSaveDirectory, defaultOutputDirectory),
-      );
-      ogImageUrl = imageFilename
-        ? path.join(defaultOutputDirectory, imageFilename)
-        : ogImageUrl;
-    }
+  let ogImageUrl = ogResult?.ogImage?.[0].url;
+
+  if (ogImageUrl && options.cache) {
+    const imageFilename = await downloadImage(
+      new URL(ogImageUrl),
+      path.join(process.cwd(), defaultSaveDirectory, defaultOutputDirectory),
+    );
+    ogImageUrl = imageFilename
+      ? path.join(defaultOutputDirectory, imageFilename)
+      : ogImageUrl;
   }
 
   return ogImageUrl;


### PR DESCRIPTION
This pull request includes several changes to the `remark-link-card-plus` plugin, focusing on adding new options for customization, updating documentation, and enhancing tests. The most important changes include adding `noThumbnail` and `noFavicon` options, updating the `README.md` file to reflect these new options, and adding corresponding tests to ensure the new functionality works as expected.

### New options for customization:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R19-R20): Added `noThumbnail` and `noFavicon` options to the `Options` type and updated the `defaultOptions` object to include these new options. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R19-R20) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R36-R37)
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R157-R183): Updated the `getLinkCardData` function to handle the new `noThumbnail` and `noFavicon` options, and refactored the logic for fetching and caching images. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R157-R183) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L170-R216) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L187-R226)

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19): Added descriptions for the new `noThumbnail` and `noFavicon` options in the list of features and the options table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R137)

### Tests:
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R532-R608): Added tests for the `noThumbnail` and `noFavicon` options to ensure that the plugin behaves correctly when these options are enabled or disabled.

### Miscellaneous:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L7-R7): Imported the `OgObject` type from `open-graph-scraper` to improve type safety.
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R9): Added `afterEach` import to clean up mocks after tests.