### PR TITLE
Add `ogTransformer` option to customize Open Graph data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can see it in action on the [demo page](https://remark-link-card-plus.pages.
 * **No link cards in lists**: Links inside list items (`listItem`) are not converted into link cards.
 * **Thumbnail position customization**: Select whether the thumbnail is displayed on the left or right of the card.
 * **Optional image and favicon display**: Added `noThumbnail` and `noFavicon` options to hide thumbnails and favicons from link cards.
+* **OG data transformer**: The `ogTransformer` option allows customization of Open Graph data such as the title, description, favicon, and image before rendering the link card.
 
 ### Retained features:
 * **Options support**:
@@ -112,6 +113,12 @@ export default defineConfig({
           thumbnailPosition: "right",
           noThumbnail: false,
           noFavicon: false,
+          ogTransformer: (og) => {
+            if (og.title === og.description) {
+              return { ...og, description: 'custom description' };
+            }
+            return og;
+          }
         },
       ],
     ],
@@ -135,6 +142,7 @@ export default defineConfig({
 | `thumbnailPosition` | string | `right`  | Specifies the position of the thumbnail in the card. Accepts `"left"` or `"right"`. |
 | `noThumbnail` | boolean | `false` | If `true`, does not display the Open Graph thumbnail image. The generated link card HTML will not contain an `<img>` tag for the thumbnail. |
 | `noFavicon`   | boolean | `false` | If `true`, does not display the favicon in the link card. The generated link card HTML will not contain an `<img>` tag for the favicon. |
+| `ogTransformer` | `(og: OgData) => OgData` | `undefined` | A callback to transform the Open Graph data before rendering. `OgData` has the structure `{ title: string; description: string; faviconUrl?: string; imageUrl?: string }`. |
 
 ## Styling
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -572,7 +572,7 @@ https://example.com
       });
 
       afterEach(() => {
-        vi.restoreAllMocks();
+        vi.clearAllMocks();
       });
 
       test("default behavior (noFavicon: false) includes favicon", async () => {
@@ -604,6 +604,48 @@ https://example.com
           'class="remark-link-card-plus__favicon"',
         );
         expect(global.fetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("ogTransformer", () => {
+      test("should allow modifying OG data via ogTransformer", async () => {
+        const markdown = `
+https://example.com
+`;
+
+        const { value } = await remark()
+          .use(remarkLinkCard, {
+            ogTransformer: (og) => ({
+              ...og,
+              title: "Custom Title",
+              description: "Overwritten Description",
+              faviconUrl: "https://custom.com/favicon.ico",
+              imageUrl: "https://custom.com/image.png",
+            }),
+          })
+          .process(markdown);
+
+        expect(value).toContain("Custom Title");
+        expect(value).toContain("Overwritten Description");
+        expect(value).toContain("https://custom.com/favicon.ico");
+        expect(value).toContain("https://custom.com/image.png");
+      });
+
+      test("should fall back to original OG data if ogTransformer is not provided", async () => {
+        const markdown = `
+https://github.com
+`;
+
+        const { value } = await remark()
+          .use(remarkLinkCard, {})
+          .process(markdown);
+
+        expect(value).toContain("Test Site Title");
+        expect(value).toContain("Test Description");
+        expect(value).toContain(
+          "https://www.google.com/s2/favicons?domain=github.com",
+        );
+        expect(value).toContain("http://example.com");
       });
     });
   });


### PR DESCRIPTION
This pull request introduces a new feature for transforming Open Graph (OG) data before rendering link cards. It also includes various updates to the codebase to support this new functionality. The most important changes are listed below:

### New Feature: OG Data Transformer

* **README.md**: Added a description of the new `ogTransformer` option, which allows customization of OG data such as the title, description, favicon, and image before rendering the link card. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R121) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145)

### Codebase Updates

* **src/index.ts**: Introduced the `OgData` type and added the `ogTransformer` option to the `Options` type. Updated the `getLinkCardData` function to apply the `ogTransformer` to OG data. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R15-R28) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L153-R176)
* **src/index.test.ts**: Added tests to verify the behavior of the `ogTransformer` option, including tests for modifying OG data and falling back to original OG data if the transformer is not provided.

### Error Handling Improvement

* **src/index.ts**: Improved error handling in the `getOpenGraph` function by making the `ogError` variable optionally undefined and using optional chaining.

### Test Maintenance

* **src/index.test.ts**: Replaced `vi.restoreAllMocks` with `vi.clearAllMocks` to ensure all mocks are cleared after each test.