### PR TITLE
Replace github action versions with hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20
           cache: npm
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: node_modules_cache_id
         env:
           cache-name: cache-node-modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '20.x'
           cache: npm
@@ -26,6 +26,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
       - name: Generate release note
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           generate_release_notes: true


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to specify exact commit hashes for the actions being used. This helps ensure consistency and security by locking dependencies to specific versions.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL9-R14): Updated `actions/checkout` to version `v4.2.2` using commit hash `11bd71901bbe5b1630ceea73d27597364c9af683`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL9-R14): Updated `actions/setup-node` to version `v4.3.0` using commit hash `cdca7365b2dadb8aad0a33bc7601856ffabcc48e`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL9-R14): Updated `actions/cache` to version `v4.2.3` using commit hash `5a3ec84eff668545956fd18022155c47e93e2684`.

Changes to Release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L13-R15): Updated `actions/checkout` to version `v4.2.2` using commit hash `11bd71901bbe5b1630ceea73d27597364c9af683`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L13-R15): Updated `actions/setup-node` to version `v4.3.0` using commit hash `cdca7365b2dadb8aad0a33bc7601856ffabcc48e`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L29-R29): Updated `softprops/action-gh-release` to version `v2.2.1` using commit hash `c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda`.