### PR TITLE
Resolve relative favicon urls from Open Graph data into valid absolute urls

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -647,6 +647,31 @@ https://github.com
         );
         expect(value).toContain("http://example.com");
       });
+
+      test("resolves relative favicon URLs into absolute ones", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: for open-graph-scraper mock
+        const mockedClient = vi.mocked(client as any);
+        mockedClient.mockResolvedValueOnce({
+          error: false,
+          result: {
+            ogTitle: "Relative Favicon",
+            ogDescription: "Favicon should be resolved",
+            favicon: "/relative-path-favicon.ico",
+          },
+        });
+
+        const markdown = `
+https://example.com
+`;
+
+        const { value } = await remark()
+          .use(remarkLinkCard, {})
+          .process(markdown);
+
+        expect(value.toString()).toContain(
+          `<img src="https://example.com/relative-path-favicon.ico" class="remark-link-card-plus__favicon"`,
+        );
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,22 @@ const getFaviconUrl = async (
 ) => {
   if (options.noFavicon) return "";
 
-  let faviconUrl = ogFavicon ?? (await getFaviconImageSrc(url));
+  let faviconUrl = ogFavicon;
+  if (faviconUrl && !URL.canParse(faviconUrl)) {
+    try {
+      faviconUrl = new URL(faviconUrl, url.origin).toString();
+    } catch (error) {
+      console.error(
+        `[remark-link-card-plus] Error: Failed to resolve favicon URL ${faviconUrl} relative to ${url}\n${error}`,
+      );
+      faviconUrl = undefined;
+    }
+  }
+
+  if (!faviconUrl) {
+    faviconUrl = await getFaviconImageSrc(url);
+  }
+
   if (faviconUrl && options.cache) {
     try {
       const faviconFilename = await downloadImage(


### PR DESCRIPTION
This pull request includes changes to improve the handling of favicon URLs in the `remark-link-card-plus` package. The most important changes include adding a new test case for resolving relative favicon URLs and updating the favicon URL resolution logic to handle relative URLs properly.

Improvements to favicon URL handling:

* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R650-R674): Added a new test case to ensure that relative favicon URLs are correctly resolved into absolute ones.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L204-R219): Updated the `getFaviconUrl` function to resolve relative favicon URLs by constructing an absolute URL using the base URL's origin. Added error handling to log any issues encountered during this process.