### PR TITLE
Add `ignoreExtensions` options to exclude link cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can see it in action on the [demo page](https://remark-link-card-plus.pages.
 * **Thumbnail position customization**: Select whether the thumbnail is displayed on the left or right of the card.
 * **Optional image and favicon display**: Added `noThumbnail` and `noFavicon` options to hide thumbnails and favicons from link cards.
 * **OG data transformer**: The `ogTransformer` option allows customization of Open Graph data such as the title, description, favicon, and image before rendering the link card.
+* **Ignore by extension**: The `ignoreExtensions` option allows you to skip link card conversion for URLs with specific file extensions (e.g., `.mp4`, `.pdf`).
 
 ### Retained features:
 * **Options support**:
@@ -51,11 +52,13 @@ https://github.com
 will be converted into a link card.
 
 Inline links like [GitHub](https://github.com) will **not** be converted.
+
+Links to files like https://example.com/video.mp4 can be ignored using the `ignoreExtensions` option.
 `;
 
 (async () => {
   const result = await remark()
-    .use(remarkLinkCard, { cache: true, shortenUrl: true })
+    .use(remarkLinkCard, { cache: true, shortenUrl: true, ignoreExtensions: ['.mp4', '.pdf'] })
     .process(exampleMarkdown);
 
   console.log(result.value);
@@ -92,6 +95,8 @@ Bare links like this:
 will be converted into a link card.
 
 Inline links like [GitHub](https://github.com) will **not** be converted.
+
+Links to files like https://example.com/video.mp4 can be ignored using the `ignoreExtensions` option.
 ```
 
 ### Astro Example
@@ -113,6 +118,7 @@ export default defineConfig({
           thumbnailPosition: "right",
           noThumbnail: false,
           noFavicon: false,
+          ignoreExtensions: ['.mp4', '.pdf'],
           ogTransformer: (og) => {
             if (og.title === og.description) {
               return { ...og, description: 'custom description' };
@@ -143,6 +149,7 @@ export default defineConfig({
 | `noThumbnail` | boolean | `false` | If `true`, does not display the Open Graph thumbnail image. The generated link card HTML will not contain an `<img>` tag for the thumbnail. |
 | `noFavicon`   | boolean | `false` | If `true`, does not display the favicon in the link card. The generated link card HTML will not contain an `<img>` tag for the favicon. |
 | `ogTransformer` | `(og: OgData) => OgData` | `undefined` | A callback to transform the Open Graph data before rendering. `OgData` has the structure `{ title: string; description: string; faviconUrl?: string; imageUrl?: string }`. |
+| `ignoreExtensions` | string[] | `[]` | Skips link card conversion for URLs with the specified file extensions (e.g., `['.mp4', '.pdf']`). The original Markdown is left unchanged for these links. Matching is case-insensitive and only exact extension matches are ignored. |
 
 ## Styling
 

--- a/example/src/content/demo/example.md
+++ b/example/src/content/demo/example.md
@@ -94,6 +94,22 @@ Output:
 
 ---
 
+### 3. Links Ignored by Extension
+
+If you configure `ignoreExtensions: [".mp4"]`, links to files with these extensions will not be converted to cards.
+
+Example:
+
+```markdown
+https://example.com/video.mp4
+```
+
+Output:
+
+https://example.com/video.mp4
+
+---
+
 ## ❌ Links Not Converted to Cards
 
 ### 1. Link with Additional Text on the Same Line

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -673,5 +673,170 @@ https://example.com
         );
       });
     });
+
+    describe("ignoreExtensions", () => {
+      test("should skip link card transformation for URLs with ignored extensions", async () => {
+        const input = `## test
+
+https://example.com
+
+https://example.com/video.mp4
+
+https://example.com/movie.mov
+
+https://example.com/image.png
+`;
+
+        const processorIgnoreExtensions = remark().use(remarkLinkCard, {
+          ignoreExtensions: [".mp4", ".mov"],
+        });
+        const { value } = await processorIgnoreExtensions.process(input);
+
+        const expected = `## test
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+
+https://example.com/video.mp4
+
+https://example.com/movie.mov
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/image.png" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+`;
+        expect(removeLineLeadingSpaces(value.toString())).toBe(
+          removeLineLeadingSpaces(expected),
+        );
+      });
+
+      test("should handle case insensitivity for file extensions", async () => {
+        const input = `## test
+
+https://example.com/video.MP4
+
+https://example.com/movie.MOV
+`;
+
+        const processorIgnoreExtensions = remark().use(remarkLinkCard, {
+          ignoreExtensions: [".mp4", ".mov"],
+        });
+        const { value } = await processorIgnoreExtensions.process(input);
+
+        const expected = `## test
+
+https://example.com/video.MP4
+
+https://example.com/movie.MOV
+`;
+
+        expect(removeLineLeadingSpaces(value.toString())).toBe(
+          removeLineLeadingSpaces(expected),
+        );
+      });
+
+      test("should handle different link formats with ignored extensions", async () => {
+        const input = `## test
+
+https://example.com/video.mp4
+
+[https://example.com/movie.mov](https://example.com/movie.mov)
+
+<https://example.com/document.pdf>
+
+[Download Video](https://example.com/other-video.mp4)
+`;
+
+        const processorIgnoreExtensions = remark().use(remarkLinkCard, {
+          ignoreExtensions: [".mp4", ".mov", ".pdf"],
+        });
+        const { value } = await processorIgnoreExtensions.process(input);
+
+        const expected = `## test
+
+https://example.com/video.mp4
+
+<https://example.com/movie.mov>
+
+<https://example.com/document.pdf>
+
+[Download Video](https://example.com/other-video.mp4)
+`;
+
+        expect(removeLineLeadingSpaces(value.toString())).toBe(
+          removeLineLeadingSpaces(expected),
+        );
+      });
+
+      test("should only ignore exact matched extensions", async () => {
+        const input = `## test
+
+https://example.com/image.png
+
+https://example.com/image.apng
+`;
+
+        const processor = remark().use(remarkLinkCard, {
+          ignoreExtensions: [".png"],
+        });
+        const { value } = await processor.process(input);
+
+        const expected = `## test
+
+https://example.com/image.png
+
+<div class="remark-link-card-plus__container">
+  <a href="https://example.com/image.apng" target="_blank" rel="noreferrer noopener" class="remark-link-card-plus__card">
+    <div class="remark-link-card-plus__main">
+      <div class="remark-link-card-plus__content">
+        <div class="remark-link-card-plus__title">Test Site Title</div>
+        <div class="remark-link-card-plus__description">Test Description</div>
+      </div>
+      <div class="remark-link-card-plus__meta">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <span class="remark-link-card-plus__url">example.com</span>
+      </div>
+    </div>
+    <div class="remark-link-card-plus__thumbnail">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+    </div>
+  </a>
+</div>
+`;
+
+        expect(removeLineLeadingSpaces(value.toString())).toBe(
+          removeLineLeadingSpaces(expected),
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Update the implementation so that links with extensions specified in `ignoreExtensions` are  ignored and left as-is in the Markdown, without any transformation.
- Update the documentation (`README.md`) to describe the `ignoreExtensions` option, including its usage, behavior, and examples.
- Add a section to the demo markdown (`example.md`) to show how links with ignored extensions (e.g., `.mp4`) are not converted to link cards.

## Details

- The plugin now leaves links with ignored extensions untouched, preserving the original Markdown format.
- The `README.md` now includes:
  - An explanation of the `ignoreExtensions` option in the features and options table.
  - Usage examples demonstrating how to use `ignoreExtensions`.
- The demo page (`example.md`) now contains an example showing that links like `https://example.com/video.mp4` are not converted to cards when `ignoreExtensions: [".mp4"]` is set.

## Tests

- Added tests to ensure that links with extensions specified in `ignoreExtensions` are not transformed.
- Added test cases to verify that only exact extension matches are ignored (e.g., `.png` is ignored but `.apng` is not).
