### PR TITLE
Support SVG favicons with charset in Content-Type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ const downloadImage = async (url: URL, saveDirectory: string) => {
     let extension = "";
 
     // NOTE: svg is text-based file formats, so file-type cannot detect it.
-    if (contentType === "image/svg+xml") {
+    if (contentType?.startsWith("image/svg+xml")) {
       extension = ".svg";
     } else if (contentType?.startsWith("image/")) {
       const fileType = await fileTypeFromBuffer(buffer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,7 +308,7 @@ const getCachedImageFilename = async (
     const contentType = response.headers.get("Content-Type");
     let extension = "";
 
-    // NOTE: svg is text-based file formats, so file-type cannot detect it.
+    // NOTE: file-type cannot detect text-based formats like SVG, so we handle image/svg+xml manually
     if (contentType?.startsWith("image/svg+xml")) {
       extension = ".svg";
     } else if (contentType?.startsWith("image/")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,7 +310,7 @@ const downloadImage = async (url: URL, saveDirectory: string) => {
       extension = ".svg";
     } else if (contentType?.startsWith("image/")) {
       const fileType = await fileTypeFromBuffer(buffer);
-      extension = fileType ? `.${fileType.ext}` : "";
+      extension = fileType ? `.${fileType.ext}` : ".png";
     }
 
     const filename = `${hash}${extension}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ const getFaviconUrl = async (
 
   if (faviconUrl && options.cache) {
     try {
-      const faviconFilename = await downloadImage(
+      const faviconFilename = await getCachedImageFilename(
         new URL(faviconUrl),
         path.join(process.cwd(), defaultSaveDirectory, defaultOutputDirectory),
       );
@@ -267,7 +267,7 @@ const getOgImageUrl = async (
   let ogImageUrl = imageUrl;
 
   if (ogImageUrl && options.cache) {
-    const imageFilename = await downloadImage(
+    const imageFilename = await getCachedImageFilename(
       new URL(ogImageUrl),
       path.join(process.cwd(), defaultSaveDirectory, defaultOutputDirectory),
     );
@@ -285,7 +285,10 @@ const extractOgImageUrl = (ogResult: OgObject | undefined) => {
     : undefined;
 };
 
-const downloadImage = async (url: URL, saveDirectory: string) => {
+const getCachedImageFilename = async (
+  url: URL,
+  saveDirectory: string,
+): Promise<string | undefined> => {
   const hash = createHash("sha256").update(decodeURI(url.href)).digest("hex");
 
   try {


### PR DESCRIPTION
This pull request introduces enhancements to favicon and image caching logic, particularly for handling `.svg` files, and refactors the image download function for improved clarity and functionality. It also adds new test cases to ensure the correctness of these changes.

### Enhancements to favicon and image caching:

* Updated `downloadImage` to `getCachedImageFilename` and improved handling of `.svg` files by explicitly checking for `Content-Type` headers that start with `image/svg+xml`, including cases with additional parameters like `charset`. This ensures proper file extension assignment. (`src/index.ts`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L288-R291) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L308-R316)

### Refactoring:

* Replaced calls to `downloadImage` with `getCachedImageFilename` in `getFaviconUrl` and `getOgImageUrl` to align with the updated function name and logic. (`src/index.ts`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L241-R241) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L270-R270)

### New test cases:

* Added tests to validate caching behavior for `.svg` favicons, including scenarios with `Content-Type` headers containing parameters like `charset`. These tests ensure the correct handling and caching of `.svg` files. (`src/index.test.ts`, [src/index.test.tsR459-R532](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R459-R532))