### PR TITLE
fix: replace alt with empty text

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Bare links like this:
         <div class="remark-link-card-plus__description">Join the world's most widely adopted, AI-powered developer platform where millions of developers, businesses, and the largest open source community build software that advances humanity.</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=github.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=github.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">github.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="https://github.githubassets.com/assets/home24-5939032587c9.jpg" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="https://github.githubassets.com/assets/home24-5939032587c9.jpg" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -84,12 +84,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -102,12 +102,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -120,12 +120,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -138,12 +138,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -156,12 +156,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -174,12 +174,12 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -302,7 +302,7 @@ https://example.com/path
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -339,7 +339,7 @@ https://example.com/path
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
@@ -377,7 +377,7 @@ https://example.com/path
         <div class="remark-link-card-plus__description">evil description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
@@ -556,7 +556,7 @@ https://example.com
         const processorWithDefaultThumbnail = remark().use(remarkLinkCard, {});
         const { value } = await processorWithDefaultThumbnail.process(input);
         expect(removeLineLeadingSpaces(value.toString())).toContain(
-          `<img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+          `<img src="http://example.com" class="remark-link-card-plus__image" alt="">
 </div>
 </a>
 `,
@@ -599,7 +599,9 @@ https://example.com
           thumbnailPosition: "left",
         });
         const { value } = await processorWithoutThumbnail.process(input);
-        expect(value.toString()).not.toContain(`alt="ogImage"`);
+        expect(value.toString()).not.toContain(
+          `class="remark-link-card-plus__thumbnail"`,
+        );
       });
     });
 
@@ -614,7 +616,7 @@ https://example.com
           .process(markdown);
 
         expect(result.value).toContain(
-          '<img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">',
+          '<img src="http://example.com" class="remark-link-card-plus__image" alt="">',
         );
         expect(result.value).toContain('class="remark-link-card-plus__image"');
       });
@@ -625,7 +627,7 @@ https://example.com
           .process(markdown);
 
         expect(result.value).not.toContain(
-          '<img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">',
+          '<img src="http://example.com" class="remark-link-card-plus__image" alt="">',
         );
         expect(result.value).not.toContain(
           'class="remark-link-card-plus__image"',
@@ -654,7 +656,7 @@ https://example.com
           .process(markdown);
 
         expect(result.value).toContain(
-          '<img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">',
+          '<img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">',
         );
         expect(result.value).toContain(
           'class="remark-link-card-plus__favicon"',
@@ -671,7 +673,7 @@ https://example.com
           .process(markdown);
 
         expect(result.value).not.toContain(
-          '<img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">',
+          '<img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">',
         );
         expect(result.value).not.toContain(
           'class="remark-link-card-plus__favicon"',
@@ -841,12 +843,12 @@ https://example.com/image.png
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -863,12 +865,12 @@ https://example.com/movie.mov
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>
@@ -961,12 +963,12 @@ https://example.com/image.png
         <div class="remark-link-card-plus__description">Test Description</div>
       </div>
       <div class="remark-link-card-plus__meta">
-        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="favicon">
+        <img src="https://www.google.com/s2/favicons?domain=example.com" class="remark-link-card-plus__favicon" width="14" height="14" alt="">
         <span class="remark-link-card-plus__url">example.com</span>
       </div>
     </div>
     <div class="remark-link-card-plus__thumbnail">
-      <img src="http://example.com" class="remark-link-card-plus__image" alt="ogImage">
+      <img src="http://example.com" class="remark-link-card-plus__image" alt="">
     </div>
   </a>
 </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ const createLinkCardNode = (data: LinkCardData, options: Options): Html => {
   const thumbnail = ogImageUrl
     ? `
 <div class="${className("thumbnail")}">
-  <img src="${ogImageUrl}" class="${className("image")}" alt="ogImage">
+  <img src="${ogImageUrl}" class="${className("image")}" alt="">
 </div>`.trim()
     : "";
 
@@ -358,7 +358,7 @@ const createLinkCardNode = (data: LinkCardData, options: Options): Html => {
     <div class="${className("description")}">${sanitizeHtml(description)}</div>
   </div>
   <div class="${className("meta")}">
-    ${faviconUrl ? `<img src="${faviconUrl}" class="${className("favicon")}" width="14" height="14" alt="favicon">` : ""}
+    ${faviconUrl ? `<img src="${faviconUrl}" class="${className("favicon")}" width="14" height="14" alt="">` : ""}
     <span class="${className("url")}">${sanitizeHtml(displayUrl)}</span>
   </div>
 </div>


### PR DESCRIPTION
I replaced alt text for `<img>` element with empty text because it isn't useful and redundant for screen reader speech (the content of og image is conveyed as the title of link card and the content of favicon is conveyed as the site url).
And even when it is shown as a fallback for the image which browser failed to fetch, the text such as "ogImage" or "favicon" doesn't convey useful information.

Checking some SNS link cards, alt text for og image and favicon is set to `""` (empty string), so this can be thought to be a common case.

favicon in sizu.me
<img width="2209" height="509" alt="image" src="https://github.com/user-attachments/assets/50f1f58a-cd2c-411c-9da7-53f6267511b8" />

og image in Mastodon
<img width="1693" height="656" alt="image" src="https://github.com/user-attachments/assets/26fd0c7d-3bc2-4d24-aff9-3a654423a37b" />
