### PR TITLE
feat: Updated the minimum required Node.js version to 22.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
           cache: npm
       - name: Install npm packages
         run: npm ci
-      - name: Build
-        run: npm run build
-      - name: Run Test
-        run: npm run test
-      - name: Run Lint and Formatter
-        run: npm run check:ci
+      - parallel:
+          - name: Build
+            run: npm run build
+          - name: Run Test
+            run: npm run test
+          - name: Run Lint and Formatter
+            run: npm run check:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: ["22.13.0", 24, 26]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: node_modules_cache_id
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-      - if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
-        name: Install npm packages
-        run: npm install
+      - name: Install npm packages
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Run Test
         run: npm run test
       - name: Run Lint and Formatter

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can see it in action on the [demo page](https://remark-link-card-plus.pages.
 
 ## Install
 
+Node.js 22.13.0 or later is required.
+
 ```sh
 npm i remark-link-card-plus
 ```

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -17,7 +17,7 @@
       }
     },
     "..": {
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "file-type": "^22.0.1",
@@ -37,7 +37,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/okaryo/remark-link-card-plus.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13.0"
   },
   "keywords": [
     "unified",


### PR DESCRIPTION
This pull request updates the project to require Node.js 22.13.0 or later and makes several changes to the CI workflow and related configuration files to reflect this new requirement. It also updates dependencies and improves the installation process.

**Node.js version requirement updates:**

* Updated the minimum required Node.js version to 22.13.0 in `package.json`, `example/package-lock.json`, and documented this requirement in `README.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23-R23) [[2]](diffhunk://#diff-2e0b878f7b113ee690dd8259e32de2c534d08b192b8d6c9ed50e05ac90d813a0L40-R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32)

**CI workflow improvements:**

* Changed the Node.js versions tested in CI to use "22.13.0", 24, and 26, and switched from `npm install` to `npm ci` for faster and more reliable installs. Removed the `actions/cache` step for `node_modules` and updated the build/test/lint steps to run in parallel in `.github/workflows/ci.yml`.

**Dependency updates:**

* Bumped the local dependency version from 0.7.4 to 0.7.5 in `example/package-lock.json`.